### PR TITLE
ci: fix `rustfmt` job

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -31,8 +31,8 @@ jobs:
       - name: Run tests
         uses: actions-rs/cargo@v1.0.1
         with:
-          command: test
-          args: --all-features --verbose
+          command: fmt
+          args: -- --check
   clippy:
     name: Clippy
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description

This fixes `rustfmt` job of `check` workflow.
The job previously invoked `cargo test` instead of `cargo fmt -- --check`.